### PR TITLE
Fix typo when selecting KqueueSelector

### DIFF
--- a/selectors2.py
+++ b/selectors2.py
@@ -621,7 +621,7 @@ if hasattr(select, "kqueue"):
 # select() also can't accept a FD > FD_SETSIZE (usually around 1024)
 if 'KqueueSelector' in globals():  # Platform-specific: Mac OS and BSD
     DefaultSelector = KqueueSelector
-if 'DevpollSelector' in globals():
+elif 'DevpollSelector' in globals():
     DefaultSelector = DevpollSelector
 elif 'EpollSelector' in globals():  # Platform-specific: Linux
     DefaultSelector = EpollSelector


### PR DESCRIPTION
The logic in the conditional was forcing the DefaultSelector to use
Select instead of Kqueue on Kqueue supporting platforms.

I also checked the python-3.5 stdlib version of selectors and saw that the conditional is an elif there as well.